### PR TITLE
Include Env and parameters when expanding Macros

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -63,7 +63,7 @@
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>
             <artifactId>token-macro</artifactId>
-            <version>1.4</version>
+            <version>1.5.1</version>
         </dependency>
     </dependencies>
 

--- a/src/main/java/org/jenkins_ci/plugins/run_condition/core/BooleanCondition.java
+++ b/src/main/java/org/jenkins_ci/plugins/run_condition/core/BooleanCondition.java
@@ -53,7 +53,7 @@ public final class BooleanCondition extends AlwaysPrebuildRunCondition {
 
     @Override
     public boolean runPerform(final AbstractBuild<?, ?> build, final BuildListener listener) throws Exception {
-        final String expandedToken = Util.fixEmptyAndTrim(TokenMacro.expand(build, listener, token));
+        final String expandedToken = Util.fixEmptyAndTrim(TokenMacro.expandAll(build, listener, token));
         if (expandedToken == null) return false;
         return RUN_REGEX.matcher(expandedToken.toLowerCase()).matches();
     }

--- a/src/main/java/org/jenkins_ci/plugins/run_condition/core/ExpressionCondition.java
+++ b/src/main/java/org/jenkins_ci/plugins/run_condition/core/ExpressionCondition.java
@@ -53,8 +53,8 @@ public class ExpressionCondition extends AlwaysPrebuildRunCondition {
 
     @Override
     public boolean runPerform(final AbstractBuild<?, ?> build, final BuildListener listener) throws Exception {
-        final String expandedExpression = TokenMacro.expand(build, listener, expression);
-        String expandedLabel = TokenMacro.expand(build, listener, label);
+        final String expandedExpression = TokenMacro.expandAll(build, listener, expression);
+        String expandedLabel = TokenMacro.expandAll(build, listener, label);
         listener.getLogger().println(Messages.expressionCondition_console_args(expandedExpression, expandedLabel));
         return expandedLabel.matches(expandedExpression);
     }

--- a/src/main/java/org/jenkins_ci/plugins/run_condition/core/FileExistsCondition.java
+++ b/src/main/java/org/jenkins_ci/plugins/run_condition/core/FileExistsCondition.java
@@ -60,7 +60,7 @@ public final class FileExistsCondition extends AlwaysPrebuildRunCondition {
 
     @Override
     public boolean runPerform(final AbstractBuild<?, ?> build, final BuildListener listener) throws Exception {
-        final String expandedFile = TokenMacro.expand(build, listener, file);
+        final String expandedFile = TokenMacro.expandAll(build, listener, file);
         return baseDir.getBaseDirectory(build).child(expandedFile).exists();
     }
 

--- a/src/main/java/org/jenkins_ci/plugins/run_condition/core/NumericalComparisonCondition.java
+++ b/src/main/java/org/jenkins_ci/plugins/run_condition/core/NumericalComparisonCondition.java
@@ -66,9 +66,9 @@ public final class NumericalComparisonCondition extends AlwaysPrebuildRunConditi
 
     @Override
     public boolean runPerform(final AbstractBuild<?, ?> build, final BuildListener listener) throws Exception {
-        final String leftString = TokenMacro.expand(build, listener, lhs);
+        final String leftString = TokenMacro.expandAll(build, listener, lhs);
         final double left = Double.parseDouble(leftString);
-        final String rightString = TokenMacro.expand(build, listener, rhs);
+        final String rightString = TokenMacro.expandAll(build, listener, rhs);
         final double right = Double.parseDouble(rightString);
         listener.getLogger().println(Messages.numericalComparison_console_args(left, comparator.getDescriptor().getDisplayName(), right));
         return comparator.isTrue(left, right);

--- a/src/main/java/org/jenkins_ci/plugins/run_condition/core/StringsMatchCondition.java
+++ b/src/main/java/org/jenkins_ci/plugins/run_condition/core/StringsMatchCondition.java
@@ -59,8 +59,8 @@ public class StringsMatchCondition extends AlwaysPrebuildRunCondition {
 
     @Override
     public boolean runPerform(final AbstractBuild<?, ?> build, final BuildListener listener) throws Exception {
-        final String expanded1 = TokenMacro.expand(build, listener, arg1);
-        final String expanded2 = TokenMacro.expand(build, listener, arg2);
+        final String expanded1 = TokenMacro.expandAll(build, listener, arg1);
+        final String expanded2 = TokenMacro.expandAll(build, listener, arg2);
         listener.getLogger().println(Messages.stringsMatchCondition_console_args(expanded1, expanded2));
         if (expanded1 == null) return false;
         return ignoreCase ? expanded1.equalsIgnoreCase(expanded2) : expanded1.equals(expanded2);


### PR DESCRIPTION
 [FIXED JENKINS-12411]
Change TokenMacro.expand to TokenMacro.expandAll as included added in version 1.5.1
of the TokenMacro plugin (skip 1.5.0 due to http://issues.jenkins-ci.org/browse/JENKINS-11914)

This will now expand all macros including ones from Parameter Actions.
