### PR TITLE
Add new condition: CauseCondition

### DIFF
--- a/src/main/java/org/jenkins_ci/plugins/run_condition/core/CauseCondition.java
+++ b/src/main/java/org/jenkins_ci/plugins/run_condition/core/CauseCondition.java
@@ -1,0 +1,134 @@
+/*
+ * The MIT License
+ *
+ * Copyright (C) 2011 by Anthony Robinson
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+package org.jenkins_ci.plugins.run_condition.core;
+
+import hudson.Extension;
+import hudson.cli.BuildCommand.CLICause;
+import hudson.model.BuildListener;
+import hudson.model.AbstractBuild;
+import hudson.model.Cause;
+import hudson.model.Cause.RemoteCause;
+import hudson.model.Cause.UpstreamCause;
+import hudson.model.Cause.UserCause;
+import hudson.triggers.SCMTrigger.SCMTriggerCause;
+import hudson.triggers.TimerTrigger.TimerTriggerCause;
+import hudson.util.ListBoxModel;
+
+import java.util.List;
+
+import org.jenkins_ci.plugins.run_condition.Messages;
+import org.jenkins_ci.plugins.run_condition.common.AlwaysPrebuildRunCondition;
+import org.kohsuke.stapler.DataBoundConstructor;
+
+public final class CauseCondition extends AlwaysPrebuildRunCondition {
+
+    private enum BuildCause {
+
+        USER_CAUSE(UserCause.class, "UserCause"), CLI_CAUSE(CLICause.class, "CLICause"), REMOTE_CAUSE(RemoteCause.class, "RemoteCause"), SCM_CAUSE(
+                SCMTriggerCause.class, "SCMTrigger"), TIMER_CAUSE(TimerTriggerCause.class, "TimerTrigger"), UPSTREAM_CAUSE(UpstreamCause.class, "UpstreamCause"),
+        // if XTrigger plugin is installed:
+        FS_CAUSE("org.jenkinsci.plugins.fstrigger.FSTriggerCause", "FSTrigger"), URL_CAUSE("org.jenkinsci.plugins.urltrigger.URLTriggerCause", "URLTrigger"), IVY_CAUSE(
+                "org.jenkinsci.plugins.ivytrigger.IvyTriggerCause", "IvyTrigger"), SCRIPT_CAUSE("org.jenkinsci.plugins.scripttrigger.ScriptTriggerCause",
+                "ScriptTrigger"), BUILDRESULT_CAUSE("org.jenkinsci.plugins.buildresulttrigger.BuildResultTriggerCause", "BuildResultTrigger");
+
+        public final String causeClassName;
+        public final String displayName;
+
+        /**
+         * Constructor to build causes the cause class is NOT available at build time.
+         * 
+         * @param causeClassName
+         * @param displayName
+         */
+        private BuildCause(String causeClassName, String displayName) {
+            this.causeClassName = causeClassName;
+            this.displayName = displayName;
+        }
+
+        /**
+         * Constructor to build causes the cause class is available at build time.
+         * 
+         * @param clazz
+         *            cause class
+         * @param displayName
+         *            the name to display in the UI
+         */
+        private BuildCause(Class<? extends Cause> clazz, String displayName) {
+            this.causeClassName = clazz.getName();
+            this.displayName = displayName;
+        }
+    }
+
+    private final BuildCause buildCause;
+    private final boolean exclusiveCause;
+
+    @DataBoundConstructor
+    public CauseCondition(final String buildCause, final boolean exclusiveCause) {
+        this.buildCause = BuildCause.valueOf(buildCause);
+        this.exclusiveCause = exclusiveCause;
+    }
+
+    public BuildCause getBuildCause() {
+        return buildCause;
+    }
+
+    public boolean isExclusiveCause() {
+        return exclusiveCause;
+    }
+
+    @Override
+    public boolean runPerform(final AbstractBuild<?, ?> build, final BuildListener listener) {
+        final List<Cause> causes = build.getCauses();
+        if (isExclusiveCause()) {
+            return causes.size() == 1 && buildCause.causeClassName.equals(causes.get(0).getClass().getName());
+        } else {
+            for (Cause cause : causes) {
+                if (cause.getClass().getName().equals(buildCause.causeClassName)) {
+                    return true;
+                }
+            }
+        }
+        return false;
+    }
+
+    @Extension
+    public static class CauseConditionDescriptor extends RunConditionDescriptor {
+
+        @Override
+        public String getDisplayName() {
+            return Messages.causeCondition_displayName();
+        }
+
+        public ListBoxModel doFillBuildCauseItems() {
+            ListBoxModel items = new ListBoxModel();
+            for (BuildCause cause : BuildCause.values()) {
+                items.add(new ListBoxModel.Option(cause.displayName, cause.name()));
+            }
+            return items;
+        }
+
+    }
+
+}

--- a/src/main/resources/org/jenkins_ci/plugins/run_condition/Messages.properties
+++ b/src/main/resources/org/jenkins_ci/plugins/run_condition/Messages.properties
@@ -34,6 +34,7 @@ filesMatchCondition.displayName=Files match
 stringsMatchCondition.displayName=Strings match
 timeCondition.displayName=Time
 dayCondition.displayName=Day of week
+causeCondition.displayName=Build Cause
 
 logic.and.displayName=And
 logic.or.displayName=Or

--- a/src/main/resources/org/jenkins_ci/plugins/run_condition/core/CauseCondition/config.jelly
+++ b/src/main/resources/org/jenkins_ci/plugins/run_condition/core/CauseCondition/config.jelly
@@ -1,0 +1,35 @@
+<?jelly escape-by-default='true'?>
+<!--
+  ~ The MIT License
+  ~
+  ~ Copyright (C) 2012 by Dominik Bartholdi
+  ~
+  ~ Permission is hereby granted, free of charge, to any person obtaining a copy
+  ~ of this software and associated documentation files (the "Software"), to deal
+  ~ in the Software without restriction, including without limitation the rights
+  ~ to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+  ~ copies of the Software, and to permit persons to whom the Software is
+  ~ furnished to do so, subject to the following conditions:
+  ~
+  ~ The above copyright notice and this permission notice shall be included in
+  ~ all copies or substantial portions of the Software.
+  ~
+  ~ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+  ~ IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+  ~ FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+  ~ AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+  ~ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+  ~ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+  ~ THE SOFTWARE.
+  -->
+
+<j:jelly xmlns:j="jelly:core" xmlns:f="/lib/form">
+
+    <f:entry title="${%buildCause}" field="buildCause">
+        <f:select/>
+    </f:entry>
+   <f:entry title="${%exclusiveCause}" field="exclusiveCause">
+        <f:checkbox name="exclusiveCause" checked="${instance.isExclusiveCause()}" />
+    </f:entry>
+     
+</j:jelly>

--- a/src/main/resources/org/jenkins_ci/plugins/run_condition/core/CauseCondition/config.properties
+++ b/src/main/resources/org/jenkins_ci/plugins/run_condition/core/CauseCondition/config.properties
@@ -1,0 +1,26 @@
+#
+# The MIT License
+#
+# Copyright (C) 2012 by Dominik Bartholdi
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
+#
+
+buildCause=Build Cause
+exclusiveCause=Exclusive Cause

--- a/src/main/resources/org/jenkins_ci/plugins/run_condition/core/CauseCondition/help-buildCause.html
+++ b/src/main/resources/org/jenkins_ci/plugins/run_condition/core/CauseCondition/help-buildCause.html
@@ -1,0 +1,19 @@
+<div>
+    The cause why the build was triggered. The following causes are supported:
+    <ul>
+        <li>UserCause - the build was triggered by a manual interaction</li>
+        <li>SCMTrigger - the build was triggered by a SCM change</li>
+        <li>TimerTrigger - the build was triggered by a timer</li>
+        <li>CLICause - the build was triggered by via CLI interface</li>
+        <li>RemoteCause - the build was triggered via remote interface</li>
+        <li>UpstreamCause - the build was triggered by an upstream project</li>
+    </ul>
+    The following causes are supported if the XTrigger plugin is installed:
+    <ul>
+        <li>FSTrigger - the build was triggered by a file system change (FSTrigger Plugin)</li>
+        <li>URLTrigger - the build was triggered by a URL change (URLTrigger Plugin)</li>
+        <li>IvyTrigger - the build was triggered by an Ivy dependency version has change (IvyTrigger Plugin)</li>
+        <li>ScriptTrigger - the build was triggered by a script (ScriptTrigger Plugin)</li>
+        <li>BuildResultTrigger - the build was triggered by a result of an other job (BuildResultTrigger Plugin)</li>
+    </ul>
+</div>

--- a/src/main/resources/org/jenkins_ci/plugins/run_condition/core/CauseCondition/help-exclusiveCause.html
+++ b/src/main/resources/org/jenkins_ci/plugins/run_condition/core/CauseCondition/help-exclusiveCause.html
@@ -1,0 +1,3 @@
+<div>
+    There might by multiple causes causing a build to be triggered, with this flag checked, the cause must be the only one causing this build to be triggered. 
+</div>

--- a/src/main/resources/org/jenkins_ci/plugins/run_condition/core/CauseCondition/help.html
+++ b/src/main/resources/org/jenkins_ci/plugins/run_condition/core/CauseCondition/help.html
@@ -1,0 +1,3 @@
+<div>
+    Run if the current build has a specific cause (e.g triggered by SCM or timer).
+</div>

--- a/src/main/resources/org/jenkins_ci/plugins/run_condition/core/CauseCondition/help.jelly
+++ b/src/main/resources/org/jenkins_ci/plugins/run_condition/core/CauseCondition/help.jelly
@@ -1,0 +1,28 @@
+<?jelly escape-by-default='true'?>
+<!--
+  ~ The MIT License
+  ~
+  ~ Copyright (C) 2012 by Dominik Bartholdi
+  ~
+  ~ Permission is hereby granted, free of charge, to any person obtaining a copy
+  ~ of this software and associated documentation files (the "Software"), to deal
+  ~ in the Software without restriction, including without limitation the rights
+  ~ to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+  ~ copies of the Software, and to permit persons to whom the Software is
+  ~ furnished to do so, subject to the following conditions:
+  ~
+  ~ The above copyright notice and this permission notice shall be included in
+  ~ all copies or substantial portions of the Software.
+  ~
+  ~ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+  ~ IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+  ~ FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+  ~ AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+  ~ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+  ~ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+  ~ THE SOFTWARE.
+  -->
+
+<j:jelly xmlns:j="jelly:core">
+    <div>Run if the current build has a specific cause (e.g triggered by SCM or timer).</div>
+</j:jelly>


### PR DESCRIPTION
This pull adds a new condition to the run-condition-plugin. The CauseCondition allows to define run-conditions based on the reason why a build was triggered. e.g. only execute a step if the build was triggered by a SCM change. The current implementation supports the following causes:
- UserCause - the build was triggered by a manual interaction
- SCMTrigger - the build was triggered by a SCM change
- TimerTrigger - the build was triggered by a timer
- CLICause - the build was triggered by via CLI interface
- RemoteCause - the build was triggered via remote interface
- UpstreamCause - the build was triggered by an upstream project

The following causes are supported if the XTrigger plugin is installed:
- FSTrigger - the build was triggered by a file system change (FSTrigger Plugin)
- URLTrigger - the build was triggered by a URL change (URLTrigger Plugin)
- IvyTrigger - the build was triggered by an Ivy dependency version has change (IvyTrigger Plugin)
- ScriptTrigger - the build was triggered by a script (ScriptTrigger Plugin)
- BuildResultTrigger - the build was triggered by a result of an other job (BuildResultTrigger Plugin)
