### PR TITLE
Add UserIdCause for Jenkins > 1.427 to cause condition

### DIFF
--- a/src/main/java/org/jenkins_ci/plugins/run_condition/core/CauseCondition.java
+++ b/src/main/java/org/jenkins_ci/plugins/run_condition/core/CauseCondition.java
@@ -46,19 +46,27 @@ public final class CauseCondition extends AlwaysPrebuildRunCondition {
 
     private enum BuildCause {
 
-        USER_CAUSE(UserCause.class, "UserCause"), CLI_CAUSE(CLICause.class, "CLICause"), REMOTE_CAUSE(RemoteCause.class, "RemoteCause"), SCM_CAUSE(
-                SCMTriggerCause.class, "SCMTrigger"), TIMER_CAUSE(TimerTriggerCause.class, "TimerTrigger"), UPSTREAM_CAUSE(UpstreamCause.class, "UpstreamCause"),
+        USER_CAUSE(UserCause.class, "UserCause (upto Jenkins 1.427)"),
+        // if jenkins is greater than 1.427 we need UserIdCause, use string constructor so to keep 1.409 min required.
+        USERID_CAUSE("hudson.model.Cause$UserIdCause", "UserIdCause (Jenkins 1.428 onwards)"),
+        CLI_CAUSE(CLICause.class, "CLICause"),
+        REMOTE_CAUSE(RemoteCause.class, "RemoteCause"),
+        SCM_CAUSE(SCMTriggerCause.class, "SCMTrigger"),
+        TIMER_CAUSE(TimerTriggerCause.class, "TimerTrigger"),
+        UPSTREAM_CAUSE(UpstreamCause.class, "UpstreamCause"),
         // if XTrigger plugin is installed:
-        FS_CAUSE("org.jenkinsci.plugins.fstrigger.FSTriggerCause", "FSTrigger"), URL_CAUSE("org.jenkinsci.plugins.urltrigger.URLTriggerCause", "URLTrigger"), IVY_CAUSE(
-                "org.jenkinsci.plugins.ivytrigger.IvyTriggerCause", "IvyTrigger"), SCRIPT_CAUSE("org.jenkinsci.plugins.scripttrigger.ScriptTriggerCause",
-                "ScriptTrigger"), BUILDRESULT_CAUSE("org.jenkinsci.plugins.buildresulttrigger.BuildResultTriggerCause", "BuildResultTrigger");
+        FS_CAUSE("org.jenkinsci.plugins.fstrigger.FSTriggerCause", "FSTrigger"),
+        URL_CAUSE("org.jenkinsci.plugins.urltrigger.URLTriggerCause", "URLTrigger"),
+        IVY_CAUSE("org.jenkinsci.plugins.ivytrigger.IvyTriggerCause", "IvyTrigger"),
+        SCRIPT_CAUSE("org.jenkinsci.plugins.scripttrigger.ScriptTriggerCause","ScriptTrigger"),
+        BUILDRESULT_CAUSE("org.jenkinsci.plugins.buildresulttrigger.BuildResultTriggerCause", "BuildResultTrigger");
 
         public final String causeClassName;
         public final String displayName;
 
         /**
          * Constructor to build causes the cause class is NOT available at build time.
-         * 
+         *
          * @param causeClassName
          * @param displayName
          */
@@ -69,7 +77,7 @@ public final class CauseCondition extends AlwaysPrebuildRunCondition {
 
         /**
          * Constructor to build causes the cause class is available at build time.
-         * 
+         *
          * @param clazz
          *            cause class
          * @param displayName

--- a/src/main/resources/org/jenkins_ci/plugins/run_condition/core/CauseCondition/help-buildCause.html
+++ b/src/main/resources/org/jenkins_ci/plugins/run_condition/core/CauseCondition/help-buildCause.html
@@ -1,7 +1,8 @@
 <div>
     The cause why the build was triggered. The following causes are supported:
     <ul>
-        <li>UserCause - the build was triggered by a manual interaction</li>
+        <li>UserCause - the build was triggered by a manual interaction - use with older Jenkins before 1.428 </li>
+        <li>UserIdCause - the build was triggered by a manual interaction - use with Jenkins 1.428 onwards</li>
         <li>SCMTrigger - the build was triggered by a SCM change</li>
         <li>TimerTrigger - the build was triggered by a timer</li>
         <li>CLICause - the build was triggered by via CLI interface</li>


### PR DESCRIPTION
Added the UserIdCause to the cause condition, there might be a better way of doing this so that we don't have to have the two items in the list. 
But as I am no Java expert, I don't know of any of them.

Also tidied up the enum list so that it is more readable.
