### PR TITLE
New cause condition M2ReleaseCause

### DIFF
--- a/src/main/java/org/jenkins_ci/plugins/run_condition/core/CauseCondition.java
+++ b/src/main/java/org/jenkins_ci/plugins/run_condition/core/CauseCondition.java
@@ -53,6 +53,8 @@ public final class CauseCondition extends AlwaysPrebuildRunCondition {
                 return this.causeClassName.equals(className) || "hudson.model.Cause$UserIdCause".equals(className);
             }
         },
+        // triggered by the m2release-plugin
+        M2_RELEASE_CAUSE("org.jvnet.hudson.plugins.m2release.ReleaseCause", "M2ReleaseCause"),
         // triggered by command line
         CLI_CAUSE(CLICause.class, "CLICause"),
         // remote call


### PR DESCRIPTION
The m2release-plugin ReleaseCause extends hudson.model.Cause.UserCause and could therefore not be distinguished from a default user build. I have added the additional cause, because we need conditional build steps depending on a Maven release build or a user triggered snapshot build.
