### PR TITLE
Update dependencies, use bom + new baseline

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -29,7 +29,7 @@
     <parent>
         <groupId>org.jenkins-ci.plugins</groupId>
         <artifactId>plugin</artifactId>
-        <version>3.57</version>
+        <version>4.14</version>
     </parent>
 
     <artifactId>run-condition</artifactId>
@@ -42,7 +42,7 @@
     <properties>
         <revision>1.4</revision>
         <changelist>-SNAPSHOT</changelist>
-        <jenkins.version>2.138.4</jenkins.version>
+        <jenkins.version>2.235.5</jenkins.version>
         <java.level>8</java.level>
     </properties>
 
@@ -61,11 +61,22 @@
         </developer>
     </developers>
 
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>io.jenkins.tools.bom</groupId>
+                <artifactId>bom-2.235.x</artifactId>
+                <version>19</version>
+                <scope>import</scope>
+                <type>pom</type>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
+
     <dependencies>
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>
             <artifactId>token-macro</artifactId>
-            <version>2.12</version>
         </dependency>
         <dependency>
             <groupId>org.easymock</groupId>
@@ -82,19 +93,16 @@
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>
             <artifactId>junit</artifactId>
-            <version>1.27</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>
             <artifactId>matrix-project</artifactId>
-            <version>1.13</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>
             <artifactId>mailer</artifactId>
-            <version>1.23</version>
             <scope>test</scope>
         </dependency>
     </dependencies>
@@ -107,8 +115,8 @@
   </scm>
 
     <issueManagement>
-        <system>JIRA</system>
-        <url>https://issues.jenkins-ci.org/</url>
+        <system>Jira</system>
+        <url>https://issues.jenkins.io/</url>
     </issueManagement>
 
     <distributionManagement>


### PR DESCRIPTION
Drops a few bundled plugins, noticed when updating flexible-publish-plugin