### PR TITLE
Require Java 11 and Jenkins 2.361.4 or newer

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,8 +3,12 @@ updates:
   - package-ecosystem: maven
     directory: "/"
     schedule:
-      interval: monthly
+      interval: "monthly"
     open-pull-requests-limit: 10
     target-branch: master
     labels:
       - dependencies
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "monthly"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,7 +3,7 @@ updates:
   - package-ecosystem: maven
     directory: "/"
     schedule:
-      interval: weekly
+      interval: monthly
     open-pull-requests-limit: 10
     target-branch: master
     labels:

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,17 +1,11 @@
 #!/usr/bin/env groovy
 
-// Use container agents on odd numbered builds
-// Assures that we test with container agents and without container agents
-
-def useContainerForOddBuilds = ((BUILD_ID as int) % 2) as boolean
-
 /* `buildPlugin` step provided by: https://github.com/jenkins-infra/pipeline-library */
 
 buildPlugin(
-  useContainerAgent: useContainerForOddBuilds,
+  useContainerAgent: true,
   configurations: [
-    [platform: 'linux',   jdk: '17', jenkins: '2.375'],
-    [platform: 'linux',   jdk: '11', jenkins: '2.361.2'],
-    [platform: 'windows', jdk:  '8']
+    [platform: 'windows', jdk: '17', jenkins: '2.375.1'],
+    [platform: 'linux',   jdk: '11'],
   ]
 )

--- a/pom.xml
+++ b/pom.xml
@@ -29,7 +29,7 @@
     <parent>
         <groupId>org.jenkins-ci.plugins</groupId>
         <artifactId>plugin</artifactId>
-        <version>4.51</version>
+        <version>4.53</version>
     </parent>
 
     <artifactId>run-condition</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -41,7 +41,7 @@
     <properties>
         <revision>1.6</revision>
         <changelist>-SNAPSHOT</changelist>
-        <jenkins.version>2.346.3</jenkins.version>
+        <jenkins.version>2.361.4</jenkins.version>
         <spotbugs.effort>Max</spotbugs.effort>
         <spotbugs.failOnError>true</spotbugs.failOnError>
         <spotbugs.threshold>Low</spotbugs.threshold>
@@ -67,7 +67,7 @@
         <dependencies>
             <dependency>
                 <groupId>io.jenkins.tools.bom</groupId>
-                <artifactId>bom-2.346.x</artifactId>
+                <artifactId>bom-2.361.x</artifactId>
                 <version>1763.v092b_8980a_f5e</version>
                 <scope>import</scope>
                 <type>pom</type>


### PR DESCRIPTION
## Require Java 11 and Jenkins 2.361.4 or newer

- Check dependencies monthly, not weekly
- Use dependabot to update GitHub actions
- Drop Java 8 testing in CI
- Require Jenkins 2.361.4 or newer
- Bump plugin from 4.51 to 4.53

Low volume plugin should place its next release on Java 11 and Jenkins 2.361.4 to reduce maintenance overhead for whoever adopts the plugin.

Includes #54 in this pull request

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue
